### PR TITLE
Personalizando admin view

### DIFF
--- a/monitoring/admin.py
+++ b/monitoring/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.apps import apps
 from import_export.admin import ImportExportModelAdmin
-from .models import Contact, Event, Project
+from .models import Contact, Event, Project, Organization
 
 from django_admin_listfilter_dropdown.filters import (
     DropdownFilter, RelatedOnlyDropdownFilter
@@ -104,10 +104,31 @@ class ProjectAdmin(admin.ModelAdmin):
 
     get_total.short_description = 'T'
 
+class OrganizationAdmin(admin.ModelAdmin):
+    list_display = (
+    'id', 'name', 'description', 'country', 'organization_parent', 'organization_type', 'is_implementer')
+    list_per_page = 20
+    list_max_show_all = 50
+    ordering = ['id']
+    list_filter = [
+    ('name', DropdownFilter),
+    ('country', RelatedOnlyDropdownFilter),
+   ('organization_type', RelatedOnlyDropdownFilter),
+    ]
+    search_fields = ['id', 'name', 'description', 'country__name']
+    autocomplete_fields = ('country', 'organization_type',)
+    exclude = ['id']
+
+    def organization_parent(self, object):
+        if object.organization_id is not None:
+            return object.name
+        else:
+            return ''
 
 admin.site.register(Contact, ContactAdmin)
 admin.site.register(Event, EventAdmin)
 admin.site.register(Project, ProjectAdmin)
+admin.site.register(Organization, OrganizationAdmin)
 
 models = apps.get_models()
 for model in models:

--- a/monitoring/models.py
+++ b/monitoring/models.py
@@ -145,7 +145,7 @@ class Organization(models.Model):
     name = models.TextField()
     country = models.ForeignKey('Country', on_delete=models.SET_NULL, null=True)
     organization_type = models.ForeignKey('OrganizationType', on_delete=models.SET_NULL, blank=True, null=True)
-    organization_id = models.IntegerField(blank=True, null=True)
+    organization = models.ForeignKey('self', on_delete=models.CASCADE, null=True, related_name="parent")
     description = models.CharField(max_length=255, blank=True, null=True)
     country_number = models.IntegerField(blank=True, null=True)
     is_implementer = models.BooleanField()


### PR DESCRIPTION
Modificando modelo Organization admin 
agregando:
list_display
per_page
ordering
list_filter
search_fields
autocomplete_fields
exclude

Archivos modificados:
monitoring/admin.py
 y
monitoring/models.py
se modificó modelo Organization para cambiar campo organization_id a campo referenciado al mismo modelo (self, parent)