### PR TITLE
Integracion de idioma segun usuario con session iniciada

### DIFF
--- a/hummus/settings.py
+++ b/hummus/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -133,7 +134,9 @@ USE_L10N = True
 
 USE_TZ = True
 
-
+LOCALE_PATHS = (
+ os.path.join(BASE_DIR, "locale"),
+)
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 

--- a/hummus/urls.py
+++ b/hummus/urls.py
@@ -17,6 +17,7 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from django.views.generic import TemplateView
+from django.conf.urls.i18n import i18n_patterns
 
 
 urlpatterns = [
@@ -25,5 +26,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('microsoft/', include('microsoft_auth.urls', namespace='microsoft')),
     path('',TemplateView.as_view(template_name='index.html')),
-    path('', include('monitoring.urls')),
 ]
+urlpatterns += i18n_patterns(
+    path('', include('monitoring.urls')),
+    prefix_default_language=False,
+)

--- a/monitoring/admin.py
+++ b/monitoring/admin.py
@@ -4,6 +4,17 @@ from import_export import resources, fields
 from import_export.admin import ImportExportModelAdmin
 from .models import *
 
+#<<Start Config language >>
+from django.conf import settings
+from django.contrib.auth import user_logged_in
+from django.dispatch import receiver
+
+@receiver(user_logged_in)
+def on_user_logged_in(sender, request, **kwargs):
+    languageUser = Profile.objects.filter(user_id=request.user.id).values('language')
+    if languageUser:
+        settings.LANGUAGE_CODE = languageUser[0]['language']
+#<<End Config language >>
 
 # based on https://hackernoon.com/automatically-register-all-models-in-django-admin-django-tips-481382cf75e5
 

--- a/monitoring/views.py
+++ b/monitoring/views.py
@@ -7,6 +7,17 @@ from django_tables2 import RequestConfig
 from .tables import *
 from .models import *
 
+#<<Start Config language >>
+from django.conf import settings
+from django.contrib.auth import user_logged_in
+from django.dispatch import receiver
+
+@receiver(user_logged_in)
+def on_user_logged_in(sender, request, **kwargs):
+    languageUser = Profile.objects.filter(user_id=request.user.id).values('language')
+    if languageUser:
+        settings.LANGUAGE_CODE = languageUser[0]['language']
+#<<End Config language >>
 
 class ProjectTableView(LoginRequiredMixin, PagedFilteredTableView):
     model = Project


### PR DESCRIPTION
Integración de lenguaje según usuario con sesión iniciada.

Se consulta en el modelo Profile para obtener el idioma del usuario logueado, 
en caso que no se encuentre el usuario en el modelo Profile se deja lenguaje por defecto.
Se asigna idioma en la variable LANGUAGE_CODE especificada en el archivo settings.py

Se configuró en monitoring/admin.py para el admin de django y en
monitoring/views.py para el dashboard.

          Archivos modificados:
          hummus/settings.py
          hummus/urls.py
          monitoring/admin.py
          monitoring/views.py

Nota. Se necesita generar archivos .mo con el siguiente comando
manage.py compilemessages -l lenguage-a-compilar