### PR TITLE
Config language

### DIFF
--- a/hummus/settings.py
+++ b/hummus/settings.py
@@ -140,7 +140,7 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
-SESSION_COOKIE_DOMAIN = ".hummus.cc"
+SESSION_COOKIE_DOMAIN = "localhost"
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 DJANGO_TABLES2_TEMPLATE = 'django_tables2/bootstrap4.html'

--- a/hummus/settings.py
+++ b/hummus/settings.py
@@ -140,7 +140,7 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
-SESSION_COOKIE_DOMAIN = "localhost"
+SESSION_COOKIE_DOMAIN = ".hummus.cc"
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 DJANGO_TABLES2_TEMPLATE = 'django_tables2/bootstrap4.html'

--- a/hummus/urls.py
+++ b/hummus/urls.py
@@ -17,8 +17,6 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from django.views.generic import TemplateView
-from django.conf.urls.i18n import i18n_patterns
-
 
 urlpatterns = [
     path('jet/', include('jet.urls', 'jet')),
@@ -26,8 +24,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('microsoft/', include('microsoft_auth.urls', namespace='microsoft')),
     path('',TemplateView.as_view(template_name='index.html')),
-]
-urlpatterns += i18n_patterns(
     path('', include('monitoring.urls')),
-    prefix_default_language=False,
-)
+]

--- a/monitoring/admin.py
+++ b/monitoring/admin.py
@@ -6,7 +6,6 @@ from .models import *
 from django.utils.translation import gettext_lazy as _
 
 #<<Start Config language >>
-from django.conf import settings
 from django.contrib.auth import user_logged_in
 from django.dispatch import receiver
 from django.utils import translation
@@ -17,7 +16,6 @@ def on_user_logged_in(sender, request, **kwargs):
     if languageUser:
         translation.activate(languageUser[0]['language'])
         request.session[translation.LANGUAGE_SESSION_KEY] = languageUser[0]['language']
-        #settings.LANGUAGE_CODE = languageUser[0]['language']
 #<<End Config language >>
 
 # based on https://hackernoon.com/automatically-register-all-models-in-django-admin-django-tips-481382cf75e5

--- a/monitoring/admin.py
+++ b/monitoring/admin.py
@@ -9,12 +9,15 @@ from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.contrib.auth import user_logged_in
 from django.dispatch import receiver
+from django.utils import translation
 
 @receiver(user_logged_in)
 def on_user_logged_in(sender, request, **kwargs):
     languageUser = Profile.objects.filter(user_id=request.user.id).values('language')
     if languageUser:
-        settings.LANGUAGE_CODE = languageUser[0]['language']
+        translation.activate(languageUser[0]['language'])
+        request.session[translation.LANGUAGE_SESSION_KEY] = languageUser[0]['language']
+        #settings.LANGUAGE_CODE = languageUser[0]['language']
 #<<End Config language >>
 
 # based on https://hackernoon.com/automatically-register-all-models-in-django-admin-django-tips-481382cf75e5

--- a/monitoring/views.py
+++ b/monitoring/views.py
@@ -8,7 +8,6 @@ from .tables import *
 from .models import *
 
 #<<Start Config language >>
-from django.conf import settings
 from django.contrib.auth import user_logged_in
 from django.dispatch import receiver
 from django.utils import translation
@@ -19,7 +18,6 @@ def on_user_logged_in(sender, request, **kwargs):
     if languageUser:
         translation.activate(languageUser[0]['language'])
         request.session[translation.LANGUAGE_SESSION_KEY] = languageUser[0]['language']
-        #settings.LANGUAGE_CODE = languageUser[0]['language']
 #<<End Config language >>
 
 class ProjectTableView(LoginRequiredMixin, PagedFilteredTableView):

--- a/monitoring/views.py
+++ b/monitoring/views.py
@@ -11,12 +11,15 @@ from .models import *
 from django.conf import settings
 from django.contrib.auth import user_logged_in
 from django.dispatch import receiver
+from django.utils import translation
 
 @receiver(user_logged_in)
 def on_user_logged_in(sender, request, **kwargs):
     languageUser = Profile.objects.filter(user_id=request.user.id).values('language')
     if languageUser:
-        settings.LANGUAGE_CODE = languageUser[0]['language']
+        translation.activate(languageUser[0]['language'])
+        request.session[translation.LANGUAGE_SESSION_KEY] = languageUser[0]['language']
+        #settings.LANGUAGE_CODE = languageUser[0]['language']
 #<<End Config language >>
 
 class ProjectTableView(LoginRequiredMixin, PagedFilteredTableView):


### PR DESCRIPTION
Se removió la configuración anterior y se agregó nueva configuración translation.activate,
para la asignacion de idioma al iniciar session un usuario

Archivos afectados con nueva configuracion de lenguaje
monitoring/view.py
monitoring/admin.py