### PR TITLE
habilitar traduccion en js en django

### DIFF
--- a/hummus/urls.py
+++ b/hummus/urls.py
@@ -17,6 +17,7 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from django.views.generic import TemplateView
+from django.views.i18n import JavaScriptCatalog
 
 urlpatterns = [
     path('jet/', include('jet.urls', 'jet')),
@@ -25,4 +26,5 @@ urlpatterns = [
     path('microsoft/', include('microsoft_auth.urls', namespace='microsoft')),
     path('',TemplateView.as_view(template_name='index.html')),
     path('', include('monitoring.urls')),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]

--- a/monitoring/static/js/script/dashboard_index.js
+++ b/monitoring/static/js/script/dashboard_index.js
@@ -585,13 +585,13 @@
 
         $scope.$watchCollection('nacionalidad', function () {
             $timeout(function () {
-                $scope.mapaPaises($scope.nacionalidad, 'participantes-nacionalidad', 'Participantes por Nacionalidad');
+                $scope.mapaPaises($scope.nacionalidad, 'participantes-nacionalidad', gettext('Participantes por Nacionalidad'));
             }, 10);
         });
 
         $scope.$watchCollection('paisEventos', function () {
             $timeout(function () {
-                $scope.mapaPaises($scope.paisEventos, 'pais-eventos', 'Ubicación geográfica de participantes');
+                $scope.mapaPaises($scope.paisEventos, 'pais-eventos', gettext('Ubicación geográfica de participantes'));
             }, 10);
         });
 
@@ -1119,6 +1119,5 @@
 
         $scope.refrescar();
     }
-
 
 })();

--- a/monitoring/templates/dashboard.html
+++ b/monitoring/templates/dashboard.html
@@ -22,6 +22,7 @@
     <script src="{% static 'js/lib/angular-sanitize.min.js' %}"></script>
     <script src="{% static 'js/lib/dirPagination.js' %}"></script>
     <script src="{% static 'js/adminlte.min.js' %}"></script>
+    <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
     <link href="{% static 'js/lib/select2/select2.css' %}" rel="stylesheet">
     <link href="{% static 'js/lib/select2/css/select2-addl.css' %}" rel="stylesheet">


### PR DESCRIPTION
Habilitando  traducciones en archivos js en django.

Archivos modificados
 hummus/urls.py -> inlcuyendo catalogo en la aplicacion
 monitoring/static/js/script/dashboard_index.js ->Agregandourl JavaScriptCatalog
 monitoring/templates/dashboard.html  ->Modificacion dos cadenas de prueba
