### PR TITLE
cambiando espacio en traducciones js con codigo html

### DIFF
--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-02 19:39+0000\n"
+"POT-Creation-Date: 2019-09-05 21:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,7 +123,7 @@ msgid "Participants reached, by sex"
 msgstr ""
 
 #: monitoring/static/js/script/dashboard_index.js:817
-msgid "Total amount "
+msgid "Total amount&nbsp;"
 msgstr ""
 
 #: monitoring/static/js/script/dashboard_index.js:834
@@ -136,11 +136,11 @@ msgid "ORGANIZATIONS"
 msgstr ""
 
 #: monitoring/static/js/script/dashboard_index.js:858
-msgid " total, in "
+msgid "&nbsp;total, in&nbsp;"
 msgstr ""
 
 #: monitoring/static/js/script/dashboard_index.js:858
-msgid " Categories"
+msgid "&nbsp;Categories"
 msgstr ""
 
 #: monitoring/static/js/script/dashboard_index.js:879

--- a/monitoring/static/js/script/dashboard_index.js
+++ b/monitoring/static/js/script/dashboard_index.js
@@ -814,7 +814,7 @@
                         type: 'pie'
                     },
                     title: highchartsOpciones.title(gettext('Participants reached, by sex')),
-                    subtitle: {text: gettext('Total amount ') + $scope.dataTotales.total},
+                    subtitle: {text: gettext('Total amount&nbsp;') + $scope.dataTotales.total},
                     tooltip: {pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'},
                     plotOptions: {
                         pie: {
@@ -855,7 +855,7 @@
                 var opciones = {
 
                     title: highchartsOpciones.title(gettext('ORGANIZATIONS')),
-                    subtitle: {text: $scope.organizacionesObj.total + gettext(' total, in ') + $scope.organizacionesObj.total_categorias + gettext(' Categories')},
+                    subtitle: {text: $scope.organizacionesObj.total + gettext('&nbsp;total, in&nbsp;') + $scope.organizacionesObj.total_categorias + gettext('&nbsp;Categories')},
 
                     series: [{
                         type: 'treemap',


### PR DESCRIPTION
Se modificó espacio en los gráficos js de cadenas que no contenian código html para dejar espacios en blanco necesarios.