### PR TITLE
Fix dupes modal

### DIFF
--- a/monitoring/templates/_contact_merge_modal.html
+++ b/monitoring/templates/_contact_merge_modal.html
@@ -55,7 +55,7 @@
                         {% verbatim %}
                         <table class="table" style="display: block; overflow-y: scroll; max-height: 500px;">
                             <tr v-for="(values, key) in modelsResolve" v-if="showAttribute(key)">
-                                <th>{{ modelLabels[key] }}</th>
+                                <th>{{ modelLabels[key.replace('_id','')] }}</th>
                                 <td>
                                     <select class="form-control" v-model="modelMerge[key]" v-if="showField(key)">
                                         <option v-for="value in values">{{ value }}</option>


### PR DESCRIPTION
Eliminando '_id' de las keys en el arreglo de objetos modelsResolve, ya que modelLabels sus indices no cuentan con '_id' haciendo un conflicto en la busqueda de keys