### PR TITLE
conteo de duplicados en python (no ORM)

### DIFF
--- a/monitoring/models.py
+++ b/monitoring/models.py
@@ -179,11 +179,11 @@ class ContactQuerySet(models.QuerySet):
     def for_user(self, user):
         if hasattr(user, 'profile'):
             if user.profile.projects.exists():
-                return self.filter(projectcontact__project__in=user.profile.projects.all())
+                return self.filter(projectcontact__project__in=user.profile.projects.all()).distinct()
             if user.profile.countries.exists():
-                return self.filter(projectcontact__project__countries__in=user.profile.countries.all())
+                return self.filter(country__in=user.profile.countries.all())
             if user.profile.lwrregions.exists():
-                return self.filter(projectcontact__project__countries__lwrregion__in=user.profile.lwrregions.all())
+                return self.filter(country__lwrregion__in=user.profile.lwrregions.all())
         else:
             raise PermissionDenied(_("Current user has no profile."))
         return self


### PR DESCRIPTION
usar annotate y count > 1, generaba errores porque se perdía el distinct del filtro por proyecto de contactos (for_user).  se paso este calculo a python puro.