### PR TITLE
reparando accion de copiar en portapapeles

### DIFF
--- a/monitoring/templates/modular_template/dashboard.html
+++ b/monitoring/templates/modular_template/dashboard.html
@@ -80,7 +80,7 @@
                                 </small>
                             </div>
                             <div class="header-block">
-                                <input v-model="currentUrl" type="hidden" id="urlCopy">
+                                <input v-model="currentUrl" style="position: absolute;top: -1000px"  type="text" id="urlCopy">
                                 <h3 class="title">{% trans 'Share' %}</h3>
                                 <small>
                                     <a href="javascript:;" data-toggle="tooltip" data-placement="top"


### PR DESCRIPTION
Navegador se queda que no puede ocultarse el input que contenga el contenido a copiar
