### PR TITLE
Reparando llenado tabla geografica

### DIFF
--- a/monitoring/static/js/dashboard-vue.js
+++ b/monitoring/static/js/dashboard-vue.js
@@ -160,7 +160,6 @@ var app = new Vue({
             });
         });
 
-        this.loadCountriesMaps();
         this.filterByParametersInUrl()
     },
     methods: {
@@ -388,6 +387,7 @@ var app = new Vue({
                         });
                     }
                     this.btnClick = false;
+                    this.loadCountriesMaps();
                 });
 
             $.get(UrlsAcciones.UrlLWRregions, this.requestParameters)

--- a/monitoring/static/js/mixins/geographicsMixins.js
+++ b/monitoring/static/js/mixins/geographicsMixins.js
@@ -61,9 +61,12 @@ var geographicsMixins = {
                     this.dataTableGeographic = [];
 
                     data.participants.forEach((country_data) => {
-                        let data = this.list_countries.find((item) => {
+                        let country = this.list_countries.find((item) => {
                             return item.name === country_data.name;
                         });
+
+                        console.log(this.list_countries);
+                        console.log(country);
 
                         this.dataTableGeographic.push({
                             id: country_data.id,
@@ -72,8 +75,8 @@ var geographicsMixins = {
                             total_participants: country_data.total,
                             total_target: country_data.total_target,
                             percentage_participants: country_data.percentage.toFixed(2),
-                            projects: data.projects,
-                            subprojects: data.subprojects,
+                            projects: country.projects,
+                            subprojects: country.subprojects,
                         });
                     });
 


### PR DESCRIPTION
el problema es que a veces se ejecutaba la api de geografia mucho antes de la de paises ocacionando que la tabla mostrara undefined en vez de un valor numero para cantidadesd de proyectos y subproyectos, y la de geografia depende que la lista de paises de paises este llena previamente, 